### PR TITLE
Add TableProperties and TableCellProperties to table editor

### DIFF
--- a/src/ckeditor.js
+++ b/src/ckeditor.js
@@ -24,6 +24,8 @@ import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
 import PasteFromOffice from '@ckeditor/ckeditor5-paste-from-office/src/pastefromoffice';
 import Table from '@ckeditor/ckeditor5-table/src/table';
 import TableToolbar from '@ckeditor/ckeditor5-table/src/tabletoolbar';
+import TableProperties from '@ckeditor/ckeditor5-table/src/tableproperties';
+import TableCellProperties from '@ckeditor/ckeditor5-table/src/tablecellproperties';
 import TextTransformation from '@ckeditor/ckeditor5-typing/src/texttransformation';
 import HorizontalLine from '@ckeditor/ckeditor5-horizontal-line/src/horizontalline';
 import Alignment from '@ckeditor/ckeditor5-alignment/src/alignment';
@@ -78,6 +80,8 @@ ClassicEditor.builtinPlugins = [
 	Font,
 	CodeBlock,
 	FullScreen,
+	TableProperties,
+	TableCellProperties
 ];
 
 // Editor configuration.
@@ -158,7 +162,9 @@ ClassicEditor.defaultConfig = {
 		contentToolbar: [
 			'tableColumn',
 			'tableRow',
-			'mergeTableCells'
+			'mergeTableCells',
+			'tableProperties',
+			'tableCellProperties'
 		]
 	},
 	heading: {


### PR DESCRIPTION
This adds two buttons to the Table editor bar, Table Properties and Cell Properties, which allows for superior control over table sizing and styling and individual cell sizing and styling.

![image](https://user-images.githubusercontent.com/7953020/109568949-803e8580-7a9c-11eb-98aa-97ba1a7de12d.png)
![image](https://user-images.githubusercontent.com/7953020/109568823-4ff6e700-7a9c-11eb-9b24-1f4214c7aa6d.png)